### PR TITLE
Fix console output

### DIFF
--- a/src/ConsoleOutput.php
+++ b/src/ConsoleOutput.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Behat\TeamCityFormatter;
+
+use Behat\Testwork\Output\Printer\OutputPrinter;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Class ConsoleOutput
+ * 
+ * This class is responsible for displaying the formatted text on the console. 
+ *
+ * @package Behat\TeamCityFormatter
+ *
+ * @author Geza Buza <bghome@gmail.com>
+ */
+class ConsoleOutput implements OutputPrinter
+{
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var array
+     */
+    private $styles;
+
+    public function __construct(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * Sets output path.
+     *
+     * @param string $path
+     */
+    public function setOutputPath($path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * Returns output path.
+     *
+     * @return null|string
+     *
+     * @deprecated since 3.1, to be removed in 4.0
+     */
+    public function getOutputPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * Sets output styles.
+     *
+     * @param array $styles
+     */
+    public function setOutputStyles(array $styles)
+    {
+        $this->styles = $styles;
+    }
+
+    /**
+     * Returns output styles.
+     *
+     * @return array
+     *
+     * @deprecated since 3.1, to be removed in 4.0
+     */
+    public function getOutputStyles()
+    {
+        return $this->styles;
+    }
+
+    /**
+     * Forces output to be decorated.
+     *
+     * @param Boolean $decorated
+     */
+    public function setOutputDecorated($decorated)
+    {
+        $this->output->setDecorated($decorated);
+    }
+
+    /**
+     * Returns output decoration status.
+     *
+     * @return null|Boolean
+     *
+     * @deprecated since 3.1, to be removed in 4.0
+     */
+    public function isOutputDecorated()
+    {
+        return $this->output->isDecorated();
+    }
+
+    /**
+     * Sets output verbosity level.
+     *
+     * @param integer $level
+     */
+    public function setOutputVerbosity($level)
+    {
+        $this->output->setVerbosity($level);
+    }
+
+    /**
+     * Returns output verbosity level.
+     *
+     * @return integer
+     *
+     * @deprecated since 3.1, to be removed in 4.0
+     */
+    public function getOutputVerbosity()
+    {
+        return $this->output->getVerbosity();
+    }
+
+    /**
+     * Writes message(s) to output stream.
+     *
+     * @param string|array $messages message or array of messages
+     */
+    public function write($messages)
+    {
+        $this->output->write($messages);
+    }
+
+    /**
+     * Writes newlined message(s) to output stream.
+     *
+     * @param string|array $messages message or array of messages
+     */
+    public function writeln($messages = '')
+    {
+        $this->output->writeln($messages);
+    }
+
+    /**
+     * Clear output stream, so on next write formatter will need to init (create) it again.
+     */
+    public function flush()
+    {
+    }
+
+}

--- a/src/TeamCityFormatter.php
+++ b/src/TeamCityFormatter.php
@@ -14,7 +14,6 @@ use Behat\Behat\EventDispatcher\Event\FeatureTested;
 use Behat\Behat\EventDispatcher\Event\OutlineTested;
 use Behat\Behat\EventDispatcher\Event\ScenarioTested;
 use Behat\Behat\EventDispatcher\Event\StepTested;
-use Behat\Behat\Output\Printer\ConsoleOutputPrinter;
 use Behat\Gherkin\Node\ScenarioLikeInterface;
 use Behat\Testwork\Call\CallResult;
 use Behat\Testwork\EventDispatcher\Event\AfterSuiteTested;
@@ -37,12 +36,22 @@ class TeamCityFormatter implements Formatter
     );
 
     /**
-     * @var ConsoleOutputPrinter
+     * @var OutputPrinter
      */
     protected $printer;
 
     /** @var CallResult|null */
     private $failedStep;
+
+    /**
+     * TeamCityFormatter constructor.
+     * 
+     * @param OutputPrinter $printer
+     */
+    public function __construct(OutputPrinter $printer)
+    {
+        $this->printer = $printer;
+    }
 
     /**
      * @inheritdoc
@@ -109,7 +118,6 @@ class TeamCityFormatter implements Formatter
      */
     public function getOutputPrinter()
     {
-        $this->printer = new ConsoleOutputPrinter();
         return $this->printer;
     }
 

--- a/src/TeamCityFormatterExtension.php
+++ b/src/TeamCityFormatterExtension.php
@@ -8,6 +8,7 @@ use Behat\Testwork\ServiceContainer\ExtensionManager;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 class TeamCityFormatterExtension implements Extension
 {
@@ -47,7 +48,10 @@ class TeamCityFormatterExtension implements Extension
      */
     public function load(ContainerBuilder $container, array $config)
     {
-        $definition = new Definition("Behat\\TeamCityFormatter\\TeamCityFormatter");
+        $outputDefinition = new Reference('cli.output');
+        $outputPrinterDefinition = new Definition('Behat\\TeamCityFormatter\\ConsoleOutput', array($outputDefinition));
+
+        $definition = new Definition("Behat\\TeamCityFormatter\\TeamCityFormatter", array($outputPrinterDefinition));
         $definition->addTag(OutputExtension::FORMATTER_TAG, array('priority' => 90));
 
         $container->setDefinition(OutputExtension::FORMATTER_TAG . '.teamcity', $definition);


### PR DESCRIPTION
This is a possible solution to [issue #1](https://github.com/anho/BehatFormatterTeamcity/issues/1).

The class `Behat\Behat\Output\Printer\ConsoleOutputPrinter` has been removed from Behat 3.1, making the extension unable to operate properly.
This commit substitutes that class with a new `ConsoleOutput` class. This class implements the `OutputPrinter` interface, which has not changed between Behat versions. So it makes the extension compatible with Behat 3.x versions. The actual printing to console is carried out by Symfony's `ConsoleOutput` class.
