### PR TITLE
Resolve fatal error onAfterSuiteTested

### DIFF
--- a/src/TeamCityFormatter.php
+++ b/src/TeamCityFormatter.php
@@ -135,7 +135,7 @@ class TeamCityFormatter implements Formatter
         $this->writeServiceMessage('testSuiteStarted', array('name' => $event->getSuite()->getName()));
     }
 
-    public function onAfterSuiteTested(AfterSuiteTested $event)
+    public function onAfterSuiteTested(SuiteTested $event)
     {
         $this->writeServiceMessage('testSuiteFinished', array('name' => $event->getSuite()->getName()));
     }


### PR DESCRIPTION
The onAfterSuiteTested is expecting AfterSuiteTested but it receives AfterSuiteAborted. Both classes extend from SuiteTested. In the method it only asks for getSuite()->getName() that is available in SuiteTested.

`PHP Catchable fatal error:  Argument 1 passed to Behat\TeamCityFormatter\TeamCityFormatter::onAfterSuiteTested() must be an instance of Behat\Testwork\EventDispatcher\Event\AfterSuiteTested, instance of Behat\Testwork\EventDispatcher\Event\AfterSuiteAborted given in /var/lib/teamcity-agent/work/acceptance-tests/vendor/anho/behat-formatter-teamcity/src/TeamCityFormatter.php on line 138`
